### PR TITLE
Gravatar Integration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,6 +77,7 @@ To enable Gravatar in actuator-ui, you should add the followin to your `applicat
 
 To modify the default rating and gravatar fallback image please refer to the https://github.com/rpalcolea/grails-gravatar[Gravatar Plugin Documentation]
 
+*IMPORTANT NOTE: when `spring security` and `gravatar` are enabled, the plugin grabs the username to look for the gravatar. In this case the username should be a valid email otherwise it will fallback to the default gravatar image.*
 
 === Sample 
 Sample apps with Spring Security Core integration:  

--- a/README.adoc
+++ b/README.adoc
@@ -60,6 +60,23 @@ grails:
                     - pattern: '/actuator/**'
                       access: ['hasRole("ROLE_ADMIN")']
 ```
+=== Avatar support
+Actuator-ui ships with Gravatar plugin. It will render a gravatar image under the following circumstances:
+
+ - Spring Security is installed
+ - The user is logged in 
+ - Gravatar is enabled for actuator-ui
+
+To enable Gravatar in actuator-ui, you should add the followin to your `application.yml`.
+
+```yaml
+ actuator:
+     gravatar:
+         enabled: true
+```
+
+To modify the default rating and gravatar fallback image please refer to the https://github.com/rpalcolea/grails-gravatar[Gravatar Plugin Documentation]
+
 
 === Sample 
 Sample apps with Spring Security Core integration:  

--- a/actuator-ui/build.gradle
+++ b/actuator-ui/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     compile "org.grails:grails-web-boot"
     compile "org.grails.plugins:cache"
     compile "org.grails.plugins:scaffolding"
+    compile 'rpalcolea.gravatar:gravatar:1.0.0'
     console "org.grails:grails-console"
     profile "org.grails.profiles:web-plugin"
     provided "org.grails:grails-plugin-services"

--- a/actuator-ui/grails-app/taglib/org/grails/plugins/actuator/ui/AvatarTagLib.groovy
+++ b/actuator-ui/grails-app/taglib/org/grails/plugins/actuator/ui/AvatarTagLib.groovy
@@ -1,0 +1,38 @@
+package org.grails.plugins.actuator.ui
+
+import grails.plugins.GrailsPluginManager
+
+class AvatarTagLib {
+
+    static namespace = "actuator"
+
+    GrailsPluginManager pluginManager
+
+    /**
+     * Outputs the Gravatar this is associated with the given email address
+     *
+     * @attr src    	Default image for asset-pipeline to be used when spring security or gravatar aren't enabled
+     * @attr alt        alt-attribute for the resulting img-element
+     * @attr cssClass   REQUIRED     class-attribute for the resulting img-element
+     */
+    def avatar = { attrs, body ->
+        String alt = attrs.remove('alt') ?: "User Image"
+        String cssClass = attrs.remove('cssClass')
+        String src = attrs.remove('default')
+
+        if(!pluginManager.hasGrailsPlugin("spring-security-core")) {
+            out << asset.image(src: src, class: cssClass, alt: alt)
+            return
+        }
+
+        def springSecurityService = grailsApplication.mainContext.getBean('springSecurityService')
+
+        if (grailsApplication.config.actuator.gravatar.enabled
+                && springSecurityService.isLoggedIn()) {
+            out << gravatar.image(email: springSecurityService.principal.username, cssClass: cssClass, alt: alt)
+        } else {
+            out << asset.image(src: src, class: cssClass, alt: alt)
+        }
+    }
+
+}

--- a/actuator-ui/grails-app/views/layouts/actuator.gsp
+++ b/actuator-ui/grails-app/views/layouts/actuator.gsp
@@ -59,7 +59,8 @@
                     </plugin:isAvailable>
                     <li class="dropdown user user-menu">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                            <asset:image src="actuator-ui/avatar5.png" class="user-image" alt="User Image"/>
+                            <actuator:avatar default="actuator-ui/avatar5.png" cssClass="user-image" alt="User Image"/>
+
                             <span class="hidden-xs">
                                 <plugin:isAvailable name="spring-security-core">
                                     <sec:ifLoggedIn><sec:username/></sec:ifLoggedIn>
@@ -73,8 +74,7 @@
                         <ul class="dropdown-menu">
                             <!-- User image -->
                             <li class="user-header">
-                                <asset:image src="actuator-ui/avatar5.png" class="img-circle" alt="User Image"/>
-
+                            <actuator:avatar default="actuator-ui/avatar5.png" cssClass="img-circle" alt="User Image"/>
                                 <p>
                                     <plugin:isAvailable name="spring-security-core">
                                         <sec:ifLoggedIn><sec:username/></sec:ifLoggedIn>
@@ -109,7 +109,7 @@
             <!-- Sidebar user panel -->
             <div class="user-panel">
                 <div class="pull-left image">
-                    <asset:image src="actuator-ui/avatar5.png" class="img-circle" alt="User Image"/>
+                    <actuator:avatar default="actuator-ui/avatar5.png" cssClass="img-circle" alt="User Image"/>
                 </div>
 
                 <div class="pull-left info">


### PR DESCRIPTION
Hi @dmahapatro 

I modified the `layout` to use gravatar in the following scenarios:
- Spring Security is installed
- The user is logged in 
- Gravatar is enabled for actuator-ui

If spring security isn't installed or the gravatar isn't enabled it will fallback to `asset-pipeline` using the default image that you currently have.

I also updated the `README.adoc` with the proper instructions  for configuration.

Please review the `AvatarTagLib` and let me know if this is the way you want it. I need to implement tests for the TagLib for code coverage sake but so far it works as expected. I'm attaching a few screenshots.

Please let me know your thoughts
- Gravatar disabled
  <img width="1425" alt="screen shot 2016-08-31 at 8 27 25 am" src="https://cloud.githubusercontent.com/assets/1625920/18135570/270a903a-6f57-11e6-9838-1d4d6dbc5616.png">
- Logged-in User where the username is an email
  <img width="1423" alt="screen shot 2016-08-31 at 8 23 20 am" src="https://cloud.githubusercontent.com/assets/1625920/18135569/2708309c-6f57-11e6-8119-bef677999d72.png">
- Logged-in User where the username isn't an email
  <img width="1418" alt="screen shot 2016-08-31 at 8 23 37 am" src="https://cloud.githubusercontent.com/assets/1625920/18135568/2706374c-6f57-11e6-946e-ca1a9eb3cb66.png">
